### PR TITLE
electrode-electrify-react-component is not compatible with 6.x of nodejs with yarn #26

### DIFF
--- a/electrify-react-component/package.json
+++ b/electrify-react-component/package.json
@@ -1,6 +1,6 @@
 {
   "name": "electrode-electrify-react-component",
-  "version": "4.4.13",
+  "version": "4.4.14",
   "description": "electrode-electrify-react-component",
   "main": "lib/index.js",
   "author": "George Weiler (https://github.com/georgeweiler)",
@@ -25,8 +25,8 @@
     "gulp": "^3.9.1"
   },
   "engines": {
-    "node": "^4.2.6",
-    "npm": "^3.5.3"
+    "node": "^4.2.6 || ^6.10",
+    "npm": "^3.5.3 || ^3.10"
   },
   "scripts": {
     "prepublish": "gulp prepublish",


### PR DESCRIPTION
* Added node/6.10 and npm/3.10 compatible engines declaration

This is a fix for issue #26.

Aside from making the changes to package.json, this was also tested by:
* Doing a `yarn add file:///...` of the module (with node 6.10 installed and active), which did not work before this change
* Ran `npm run test`
* Ran `npm run start`
* Ran `npm run demo`

Everything seemed to work the same before and after.